### PR TITLE
Fixed VoxelBrushCommand assigning brush before event

### DIFF
--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/command/VoxelBrushCommand.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/command/VoxelBrushCommand.java
@@ -82,7 +82,7 @@ public class VoxelBrushCommand extends VoxelCommand {
             snipeData.sendMessage(Messages.BRUSH_HANDLE_NOT_FOUND.replace("%arg%", args[0]));
         } else {
             IBrush oldBrush = sniper.getBrush(currentToolId);
-            IBrush newBrush = sniper.getBrush(currentToolId);
+            IBrush newBrush = sniper.instantiateBrush(brush);
 
             if (newBrush == null) {
                 snipeData.sendMessage(Messages.VOXEL_BRUSH_NO_PERMISSION);
@@ -99,10 +99,9 @@ public class VoxelBrushCommand extends VoxelCommand {
                 } else {
                     newBrush.parseParameters(args[0], additionalParameters, snipeData);
                 }
-                return true;
             }
             if (!new PlayerBrushChangedEvent(player, currentToolId, oldBrush, newBrush).callEvent().isCancelled()) {
-                sniper.setBrush(currentToolId, brush);
+                sniper.setBrush(currentToolId, newBrush);
                 sniper.displayInfo();
             }
         }

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
@@ -30,7 +30,7 @@ public class SnipeTool {
         this.snipeData = snipeData;
         messageHelper = new VoxelMessage(snipeData);
         snipeData.setVoxelMessage(messageHelper);
-        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
+        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode())) {
             this.currentBrush = brush;
         }
     }

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
@@ -66,18 +66,9 @@ public class SnipeTool {
     }
 
     public IBrush setCurrentBrush(@NotNull IBrush brush) {
-        Preconditions.checkNotNull(brush, "Can't set brush to null.");
-        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
-            previousBrush = currentBrush;
-            currentBrush = brush;
-            return brush;
-        }
-        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
-            previousBrush = currentBrush;
-            currentBrush = brush;
-            return brush;
-        }
-        return null;
+        previousBrush = currentBrush;
+        currentBrush = brush;
+        return brush;
     }
 
     public SnipeAction getActionAssigned(VoxelMaterial itemInHand) {

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
@@ -5,7 +5,10 @@ import com.github.kevindagame.brush.SnipeBrush;
 import com.github.kevindagame.util.VoxelMessage;
 import com.github.kevindagame.voxelsniper.material.VoxelMaterial;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.*;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableBiMap;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author ervinnnc
@@ -13,25 +16,22 @@ import com.google.common.collect.*;
 public class SnipeTool {
 
     private final BiMap<SnipeAction, VoxelMaterial> actionTools = HashBiMap.create();
-    Class<? extends IBrush> currentBrush;
+    IBrush currentBrush;
     VoxelMessage messageHelper;
-    ClassToInstanceMap<IBrush> brushes = MutableClassToInstanceMap.create();
+
     SnipeData snipeData;
-    private Class<? extends IBrush> previousBrush;
+    private IBrush previousBrush;
 
     protected SnipeTool(Sniper owner) {
-        this(SnipeBrush.class, new SnipeData(owner));
+        this(owner.instantiateBrush(SnipeBrush.class), new SnipeData(owner));
     }
 
-    protected SnipeTool(Class<? extends IBrush> currentBrush, SnipeData snipeData) {
+    protected SnipeTool(IBrush brush, SnipeData snipeData) {
         this.snipeData = snipeData;
         messageHelper = new VoxelMessage(snipeData);
         snipeData.setVoxelMessage(messageHelper);
-
-        IBrush newBrushInstance = instanciateBrush(currentBrush);
-        if (snipeData.owner().getPlayer().hasPermission(newBrushInstance.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
-            brushes.put(currentBrush, newBrushInstance);
-            this.currentBrush = currentBrush;
+        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
+            this.currentBrush = brush;
         }
     }
 
@@ -39,7 +39,7 @@ public class SnipeTool {
         if (currentBrush == null) {
             return null;
         }
-        return brushes.getInstance(currentBrush);
+        return currentBrush;
     }
 
     public SnipeData getSnipeData() {
@@ -65,23 +65,17 @@ public class SnipeTool {
         actionTools.inverse().remove(itemInHand);
     }
 
-    public IBrush setCurrentBrush(Class<? extends IBrush> brush) {
+    public IBrush setCurrentBrush(@NotNull IBrush brush) {
         Preconditions.checkNotNull(brush, "Can't set brush to null.");
-        IBrush brushInstance = brushes.get(brush);
-        if (brushInstance == null) {
-            brushInstance = instanciateBrush(brush);
-            Preconditions.checkNotNull(brushInstance, "Could not instanciate brush class.");
-            if (snipeData.owner().getPlayer().hasPermission(brushInstance.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
-                brushes.put(brush, brushInstance);
-                previousBrush = currentBrush;
-                currentBrush = brush;
-                return brushInstance;
-            }
-        }
-        if (snipeData.owner().getPlayer().hasPermission(brushInstance.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
+        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
             previousBrush = currentBrush;
             currentBrush = brush;
-            return brushInstance;
+            return brush;
+        }
+        if (snipeData.owner().getPlayer().hasPermission(brush.getPermissionNode()) || snipeData.owner().getPlayer().hasPermission("voxelsniper.brush.*")) {
+            previousBrush = currentBrush;
+            currentBrush = brush;
+            return brush;
         }
         return null;
     }
@@ -98,13 +92,6 @@ public class SnipeTool {
         return ImmutableBiMap.copyOf(actionTools);
     }
 
-    IBrush instanciateBrush(Class<? extends IBrush> brush) {
-        try {
-            return brush.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
-            return null;
-        }
-    }
 
     public void assignAction(SnipeAction action, VoxelMaterial itemInHand) {
         actionTools.forcePut(action, itemInHand);

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
@@ -148,7 +148,7 @@ public class Sniper {
     }
 
 
-    public IBrush setBrush(String toolId, Class<? extends IBrush> brush) {
+    public IBrush setBrush(String toolId, IBrush brush) {
         if (!tools.containsKey(toolId)) {
             return null;
         }
@@ -281,6 +281,15 @@ public class Sniper {
 
     public final void sendMessage(final @NotNull ComponentLike message) {
         this.getPlayer().sendMessage(message);
+    }
+
+    public IBrush instantiateBrush(Class<? extends IBrush> brush) {
+        try {
+            var brushInstance = brush.newInstance();
+            return brushInstance;
+        } catch (InstantiationException | IllegalAccessException e) {
+            return null;
+        }
     }
 
     public enum Action {

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
@@ -148,7 +148,7 @@ public class Sniper {
     }
 
 
-    public IBrush setBrush(String toolId, IBrush brush) {
+    public IBrush setBrush(String toolId, @NotNull IBrush brush) {
         if (!tools.containsKey(toolId)) {
             return null;
         }

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
@@ -286,10 +286,12 @@ public class Sniper {
     public IBrush instantiateBrush(Class<? extends IBrush> brush) {
         try {
             var brushInstance = brush.newInstance();
+            if(getPlayer().hasPermission(brushInstance.getPermissionNode()))
             return brushInstance;
         } catch (InstantiationException | IllegalAccessException e) {
             return null;
         }
+        return null;
     }
 
     public enum Action {

--- a/buildSrc/src/main/kotlin/voxel-core.gradle.kts
+++ b/buildSrc/src/main/kotlin/voxel-core.gradle.kts
@@ -48,7 +48,7 @@ java {
 }
 
 group = "com.github.kevindagame"
-version = "8.4.0"
+version = "8.4.1"
 //java.sourceCompatibility = JavaVersion.VERSION_16
 
 tasks.withType<JavaCompile> {


### PR DESCRIPTION
This issue fixes #106 
The brush was being assigned before the event had even fired. Now a brush will be instantiated, then passed to the event, and only if the event is successful will it apply. Instantiating the brush if the player doesn't have permission is not a problem