### PR TITLE
#114: Fixed EcoEnchant not loading with VoxelSniper 8.4.0 and above

### DIFF
--- a/buildSrc/src/main/kotlin/voxel-core.gradle.kts
+++ b/buildSrc/src/main/kotlin/voxel-core.gradle.kts
@@ -74,6 +74,7 @@ tasks {
         relocate("com.google.common", "com.github.kevindagame.voxelsniper.libs.com.google.common")
         relocate("net.kyori", "com.github.kevindagame.voxelsniper.libs.net.kyori")
         relocate("org.yaml.snakeyaml", "com.github.kevindagame.voxelsniper.libs.org.yaml.snakeyaml")
+        relocate("kotlin", "com.github.kevindagame.voxelsniper.libs.kotlin")
     }
 
     build {


### PR DESCRIPTION
closes #114 