### PR TITLE
Feat/141 default brush config

### DIFF
--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/VoxelBrushManager.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/VoxelBrushManager.java
@@ -9,7 +9,6 @@ import com.github.kevindagame.brush.polymorphic.operation.BlendOperation;
 import com.github.kevindagame.brush.shell.ShellBallBrush;
 import com.github.kevindagame.brush.shell.ShellSetBrush;
 import com.github.kevindagame.brush.shell.ShellVoxelBrush;
-import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -418,7 +417,7 @@ public class VoxelBrushManager {
      * @return Brush class
      */
     public BrushData getBrushForHandle(String handle) {
-        if(handle == null || handle.isEmpty()) {
+        if(handle == null || handle.isEmpty() || handle.equalsIgnoreCase("none")) {
             return null;
         }
 

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/VoxelBrushManager.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/VoxelBrushManager.java
@@ -418,7 +418,9 @@ public class VoxelBrushManager {
      * @return Brush class
      */
     public BrushData getBrushForHandle(String handle) {
-        Preconditions.checkNotNull(handle, "Brushhandle can not be null.");
+        if(handle == null || handle.isEmpty()) {
+            return null;
+        }
 
         return brushes.get(handle.toLowerCase());
     }
@@ -462,7 +464,8 @@ public class VoxelBrushManager {
      * @return The brush data for the default brush.
      */
     public BrushData getDefaultBrush() {
-        return brushes.get("snipe");
+        var defaultBrush = VoxelSniper.voxelsniper.getVoxelSniperConfiguration().getDefaultBrush();
+        return getBrushForHandle(defaultBrush);
     }
 
     public List<String> getBrushHandles() {

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/SnipeTool.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 public class SnipeTool {
 
     private final BiMap<SnipeAction, VoxelMaterial> actionTools = HashBiMap.create();
-    private @NotNull IBrush currentBrush;
+    private IBrush currentBrush;
     private IBrush previousBrush = null;
     private final VoxelMessage messageHelper;
     private final SnipeData snipeData;
@@ -36,7 +36,7 @@ public class SnipeTool {
         this.currentBrush = brush;
     }
 
-    public @NotNull IBrush getCurrentBrush() {
+    public IBrush getCurrentBrush() {
         return currentBrush;
     }
 
@@ -67,7 +67,7 @@ public class SnipeTool {
         actionTools.inverse().remove(itemInHand);
     }
 
-    public @NotNull IBrush setCurrentBrush(@NotNull IBrush brush) {
+    public IBrush setCurrentBrush(IBrush brush) {
         previousBrush = currentBrush;
         currentBrush = brush;
         return brush;

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/snipe/Sniper.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  *
@@ -313,6 +312,9 @@ public class Sniper {
      * @return {IBrush} The brush instance
      **/
     public @Nullable IBrush instantiateBrush(BrushData brushData, boolean force) {
+        if (brushData == null) {
+            return null;
+        }
         var brushInstance = brushData.getSupplier().get();
         if (!(brushInstance instanceof PolyBrush)) {
             brushInstance.setPermissionNode(brushData.getPermission());

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
@@ -11,6 +11,11 @@ public class VoxelSniperConfiguration {
 
     public static final String CONFIG_IDENTIFIER_UNDO_CACHE_SIZE = "undo-cache-size";
     public static final String CONFIG_IDENTIFIER_MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
+    public static final String CONFIG_IDENTIFIER_DEFAULT_BRUSH = "default-brush";
+    public static final String CONFIG_IDENTIFIER_PLOTSQUARED_INTEGRATION_ENABLED = "plotsquared-integration-enabled";
+    public static final String CONFIG_IDENTIFIER_WORLDGUARD_INTEGRATION_ENABLED = "worldguard-integration-enabled";
+    public static final String CONFIG_IDENTIFIER_UPDATE_CHECKER_ENABLED = "update-checker-enabled";
+
     public static final int DEFAULT_UNDO_CACHE_SIZE = 20;
     public static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_USE_PLOTSQUARED = false;
@@ -62,12 +67,21 @@ public class VoxelSniperConfiguration {
     }
 
     /**
+     * Returns the default brush.
+     *
+     * @return the default brush.
+     */
+    public String getDefaultBrush() {
+        return configuration.getString(CONFIG_IDENTIFIER_DEFAULT_BRUSH);
+    }
+
+    /**
      * Returns if PlotSquared integration is enabled.
      *
      * @return whether PlotSquared integration is enabled
      */
     public boolean isPlotSquaredIntegrationEnabled() {
-        return configuration.getBoolean("plotsquared-integration-enabled", DEFAULT_USE_PLOTSQUARED);
+        return configuration.getBoolean(CONFIG_IDENTIFIER_PLOTSQUARED_INTEGRATION_ENABLED, DEFAULT_USE_PLOTSQUARED);
     }
 
     /**
@@ -76,7 +90,7 @@ public class VoxelSniperConfiguration {
      * @return whether WorldGuard integration is enabled
      */
     public boolean isWorldGuardIntegrationEnabled() {
-        return configuration.getBoolean("worldguard-integration-enabled", DEFAULT_USE_WORLDGUARD);
+        return configuration.getBoolean(CONFIG_IDENTIFIER_WORLDGUARD_INTEGRATION_ENABLED, DEFAULT_USE_WORLDGUARD);
     }
 
     /**
@@ -85,6 +99,6 @@ public class VoxelSniperConfiguration {
      * @return whether the update checker is enabled
      */
     public boolean isUpdateCheckerEnabled() {
-        return configuration.getBoolean("update-checker-enabled", DEFAULT_USE_UPDATE_CHECKER);
+        return configuration.getBoolean(CONFIG_IDENTIFIER_UPDATE_CHECKER_ENABLED, DEFAULT_USE_UPDATE_CHECKER);
     }
 }

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
@@ -21,6 +21,7 @@ public class VoxelSniperConfiguration {
     private static final boolean DEFAULT_USE_PLOTSQUARED = false;
     private static final boolean DEFAULT_USE_WORLDGUARD = false;
     private static final boolean DEFAULT_USE_UPDATE_CHECKER = true;
+    private static final String DEFAULT_BRUSH = "snipe";
     private final YamlConfiguration configuration;
 
     /**
@@ -72,7 +73,7 @@ public class VoxelSniperConfiguration {
      * @return the default brush.
      */
     public String getDefaultBrush() {
-        return configuration.getString(CONFIG_IDENTIFIER_DEFAULT_BRUSH);
+        return configuration.getString(CONFIG_IDENTIFIER_DEFAULT_BRUSH, DEFAULT_BRUSH);
     }
 
     /**

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/YamlConfiguration.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/YamlConfiguration.java
@@ -55,6 +55,10 @@ public class YamlConfiguration {
     }
 
     public String getString(String path) {
+        return getString(path, null);
+    }
+
+    public String getString(String path, String defaultValue) {
         // head:a.b.c
         Object head = contents;
         String[] steps = path.split("\\.");
@@ -62,10 +66,10 @@ public class YamlConfiguration {
             if (head instanceof Map) {
                 head = ((Map<?, ?>) head).get(step);
             } else {
-                return null;
+                return defaultValue;
             }
         }
-        return (head instanceof String) ? (String) head : null;
+        return (head instanceof String) ? (String) head : defaultValue;
     }
 
     public int getInt(String path, int defaultValue) {

--- a/VoxelSniperCore/src/main/resources/config.yml
+++ b/VoxelSniperCore/src/main/resources/config.yml
@@ -1,6 +1,9 @@
-litesniper-max-brush-size: 5
+
 undo-cache-size: 20
 message-on-login-enabled: true
+
+# The default brush to use when a player joins the server. Default: snipe. To have no brush selected on login, set this to none.
+default-brush: snipe
 
 worldguard-integration-enabled: false
 plotsquared-integration-enabled: false

--- a/VoxelSniperCore/src/test/java/com/github/kevindagame/voxelsniper/SniperManagerTest.java
+++ b/VoxelSniperCore/src/test/java/com/github/kevindagame/voxelsniper/SniperManagerTest.java
@@ -1,9 +1,11 @@
 package com.github.kevindagame.voxelsniper;
 
+import com.github.kevindagame.VoxelBrushManager;
 import com.github.kevindagame.VoxelSniper;
 import com.github.kevindagame.snipe.Sniper;
 import com.github.kevindagame.voxelsniper.blockdata.IBlockData;
 import com.github.kevindagame.voxelsniper.entity.player.IPlayer;
+import com.github.kevindagame.voxelsniper.fileHandler.VoxelSniperConfiguration;
 import com.github.kevindagame.voxelsniper.material.IMaterial;
 import com.github.kevindagame.voxelsniper.material.VoxelMaterial;
 import org.junit.Assert;
@@ -28,6 +30,9 @@ public class SniperManagerTest {
         Mockito.when(absplayer.hasPermission(Mockito.any(String.class))).thenReturn(true);
 
         var main = Mockito.mock(IVoxelsniper.class);
+        var config = Mockito.mock(VoxelSniperConfiguration.class);
+        Mockito.when(config.getDefaultBrush()).thenReturn("snipe");
+        Mockito.when(main.getVoxelSniperConfiguration()).thenReturn(config);
         Mockito.when(main.getPlayer(uuid)).thenReturn(absplayer);
 
         IBlockData airBlockData = Mockito.mock(IBlockData.class);
@@ -38,6 +43,7 @@ public class SniperManagerTest {
         Mockito.when(main.getMaterial(VoxelMaterial.AIR)).thenReturn(mat);
 
         VoxelSniper.voxelsniper = main;
+        VoxelBrushManager.initialize();
 
         Sniper sniper = new Sniper(absplayer);
         Mockito.when(absplayer.getSniper()).thenReturn(sniper);

--- a/VoxelSniperCore/src/test/java/com/github/kevindagame/voxelsniper/YamlTest.java
+++ b/VoxelSniperCore/src/test/java/com/github/kevindagame/voxelsniper/YamlTest.java
@@ -15,6 +15,7 @@ public class YamlTest {
         YamlConfiguration config = new YamlConfiguration(f);
 
         Assert.assertNull(config.getString("nonexistent"));
+        Assert.assertEquals(config.getString("nonexistent", "Hello World!"), "Hello World!");
         Assert.assertSame(42, config.getInt("nonexistent", 42));
         Assert.assertTrue(config.getBoolean("nonexistent", true));
         Assert.assertFalse(config.getBoolean("nonexistent", false));

--- a/VoxelSniperSpigot/src/main/java/com/github/kevindagame/voxelsniper/VoxelSniperListener.java
+++ b/VoxelSniperSpigot/src/main/java/com/github/kevindagame/voxelsniper/VoxelSniperListener.java
@@ -68,11 +68,10 @@ public class VoxelSniperListener implements Listener {
     @EventHandler
     public final void onPlayerJoin(final PlayerJoinEvent event) {
         IPlayer player = SpigotVoxelSniper.getInstance().getPlayer(event.getPlayer());
+        if(!player.hasPermission(SNIPER_PERMISSION)) return;
+
         Sniper sniper = player.getSniper();
 
-        if (player.hasPermission(SNIPER_PERMISSION) && plugin.getVoxelSniperConfiguration().isMessageOnLoginEnabled()) {
-            sniper.displayInfo();
-        }
         //if player is operator
         if (event.getPlayer().isOp()) {
             var latestVersion = VersionChecker.Companion.getLATEST_VERSION();
@@ -80,6 +79,9 @@ public class VoxelSniperListener implements Listener {
             if (latestVersion != null) {
                 player.sendMessage(Messages.UPDATE_AVAILABLE.replace("%currentVersion%", plugin.getDescription().getVersion()).replace("%latestVersion%", latestVersion.getLatestVersion()).replace("%downloadUrl%", latestVersion.getDownloadUrl()));
             }
+        }
+        if (plugin.getVoxelSniperConfiguration().isMessageOnLoginEnabled()) {
+            sniper.displayInfo();
         }
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 🖼️ Include relevant screenshots.
     - 📖 Try to limit pull request to a single feature

-->

## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Refactor
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This pull request adds the functionality to change the default brush.
By changing the value in the config, the brush that is set when a player joins is changed. Setting the value to none or making it empty will make it so that no brush is selected on join.

**WARNING**
Currently configs of existing servers won't be updated.
This means that when an existing server updates voxelsniper, their default brush will always be none/unset.

## QA Instructions, Screenshots, Recordings

start a server and change the value in the config

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
  have not been included_
- [ ] I need help with writing tests
- [x] Not needed
