### PR TITLE
Add max brush size config option

### DIFF
--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/command/VoxelBrushCommand.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/command/VoxelBrushCommand.java
@@ -1,6 +1,7 @@
 package com.github.kevindagame.command;
 
 import com.github.kevindagame.VoxelBrushManager;
+import com.github.kevindagame.VoxelSniper;
 import com.github.kevindagame.brush.BrushData;
 import com.github.kevindagame.brush.IBrush;
 import com.github.kevindagame.brush.perform.IPerformerBrush;
@@ -58,10 +59,14 @@ public class VoxelBrushCommand extends VoxelCommand {
         try {
             int originalSize = snipeData.getBrushSize();
             int newSize = Integer.parseInt(args[0]);
-
             var brush = sniper.getBrush(currentToolId);
             if (brush == null) {
                 snipeData.sendMessage(Messages.NO_BRUSH_SELECTED);
+                return true;
+            }
+
+            if(newSize > VoxelSniper.voxelsniper.getVoxelSniperConfiguration().getMaxBrushSize()){
+                snipeData.sendMessage(Messages.BRUSH_SIZE_TOO_LARGE.replace("%maxBrushSize%", String.valueOf(VoxelSniper.voxelsniper.getVoxelSniperConfiguration().getMaxBrushSize())));
                 return true;
             }
 

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/util/Messages.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/util/Messages.java
@@ -359,6 +359,7 @@ public enum Messages implements ComponentLike {
     POLY_BRUSH_INFO_LINE,
     ACTION_CANCELLED,
     UPDATE_AVAILABLE,
+    BRUSH_SIZE_TOO_LARGE,
     ;
     //</editor-fold>
 

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/voxelsniper/fileHandler/VoxelSniperConfiguration.java
@@ -10,6 +10,7 @@ import java.io.File;
 public class VoxelSniperConfiguration {
 
     public static final String CONFIG_IDENTIFIER_UNDO_CACHE_SIZE = "undo-cache-size";
+    public static final String CONFIG_IDENTIFIER_MAX_BRUSH_SIZE = "max-brush-size";
     public static final String CONFIG_IDENTIFIER_MESSAGE_ON_LOGIN_ENABLED = "message-on-login-enabled";
     public static final String CONFIG_IDENTIFIER_DEFAULT_BRUSH = "default-brush";
     public static final String CONFIG_IDENTIFIER_PLOTSQUARED_INTEGRATION_ENABLED = "plotsquared-integration-enabled";
@@ -17,6 +18,7 @@ public class VoxelSniperConfiguration {
     public static final String CONFIG_IDENTIFIER_UPDATE_CHECKER_ENABLED = "update-checker-enabled";
 
     public static final int DEFAULT_UNDO_CACHE_SIZE = 20;
+    public static final int DEFAULT_MAX_BRUSH_SIZE = 20;
     public static final boolean DEFAULT_MESSAGE_ON_LOGIN_ENABLED = true;
     private static final boolean DEFAULT_USE_PLOTSQUARED = false;
     private static final boolean DEFAULT_USE_WORLDGUARD = false;
@@ -47,6 +49,15 @@ public class VoxelSniperConfiguration {
      */
     public void setUndoCacheSize(int size) {
         configuration.set(CONFIG_IDENTIFIER_UNDO_CACHE_SIZE, size);
+    }
+
+    /**
+     * Returns the maximum brush size.
+     *
+     * @return the maximum brush size
+     */
+    public int getMaxBrushSize() {
+        return configuration.getInt(CONFIG_IDENTIFIER_MAX_BRUSH_SIZE, DEFAULT_MAX_BRUSH_SIZE);
     }
 
     /**

--- a/VoxelSniperCore/src/main/resources/config.yml
+++ b/VoxelSniperCore/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 
 undo-cache-size: 20
+max-brush-size: 20
 message-on-login-enabled: true
 
 # The default brush to use when a player joins the server. Default: snipe. To have no brush selected on login, set this to none.

--- a/VoxelSniperCore/src/main/resources/lang.yml
+++ b/VoxelSniperCore/src/main/resources/lang.yml
@@ -592,4 +592,4 @@ ACTION_CANCELLED: <red>The action was cancelled
 UPDATE_AVAILABLE: |- 
   <gold>An update is available for VoxelSniper. You are running version <red>%currentVersion%</red> and the latest version is <green>%latestVersion%</green>.
   Download the latest version <green><click:OPEN_URL:%downloadUrl%><hover:show_text:Click me!>here</hover></click></green>!</gold> 
-
+BRUSH_SIZE_TOO_LARGE: <red>Brush size is too large. Maximum brush size is %maxBrushSize%.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 🖼️ Include relevant screenshots.
     - 📖 Try to limit pull request to a single feature

-->

## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Refactor
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add a max brush size config option
This will use the default value on existing servers. New implementations will use the default config which coincidentally also contains the default value.

## QA Instructions, Screenshots, Recordings
regenerate config. Change the value of max-brush-size and try to set brush size accordingly. It will prevent the user from setting a brush size greater than the max value

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Commands need a refactoring to make them testable
- [ ] I need help with writing tests
- [ ] Not needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l2Jegcut5aSRZ4wsE/giphy.gif)
