### PR TITLE
Clear worlds and player cache when logical server stops

### DIFF
--- a/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
+++ b/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
@@ -162,7 +162,9 @@ public class VoxelSniperForge implements IVoxelsniper {
         return getPlayer(ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayerByName(name));
     }
 
-    public IPlayer getPlayer(@NotNull ServerPlayer p) {
+    @Nullable
+    public IPlayer getPlayer(@Nullable ServerPlayer p) {
+        if (p == null) return null;
         if (this.players.get(p.getUUID()) != null) return this.players.get(p.getUUID());
         ForgePlayer res = new ForgePlayer(p);
         this.players.put(res.getUniqueId(), res);

--- a/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
+++ b/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
@@ -34,6 +34,7 @@ import net.minecraft.world.level.levelgen.feature.configurations.HugeMushroomFea
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -124,6 +125,13 @@ public class VoxelSniperForge implements IVoxelsniper {
     public void onServerStopping(ServerStoppingEvent event) {
         worlds.clear();
         players.clear();
+    }
+
+    @SubscribeEvent
+    public void onLevelUnload(LevelEvent.Unload event) {
+        if (event.getLevel() instanceof ServerLevel) {
+            worlds.remove(event.getLevel().toString());
+        }
     }
 
     // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent

--- a/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
+++ b/VoxelSniperForge/src/main/java/com/github/kevindagame/voxelsniperforge/VoxelSniperForge.java
@@ -34,6 +34,7 @@ import net.minecraft.world.level.levelgen.feature.configurations.HugeMushroomFea
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
@@ -132,6 +133,11 @@ public class VoxelSniperForge implements IVoxelsniper {
         if (event.getLevel() instanceof ServerLevel) {
             worlds.remove(event.getLevel().toString());
         }
+    }
+
+    @SubscribeEvent
+    public void onPlayerLeave(PlayerEvent.PlayerLoggedOutEvent event) {
+        players.remove(event.getEntity().getUUID());
     }
 
     // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 🖼️ Include relevant screenshots.
     - 📖 Try to limit pull request to a single feature

-->

## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The cache was not cleared, meaning that if you rejoined a world, the mod would still take from the cache, and crash the logical server because it's invalid.

Also implemented the unload world listener to prevent memory leak

## QA Instructions, Screenshots, Recordings

1. load a singleplayer world
2. do snipe actions
3. leave and load again
4. do snipe actions
5. see that it works

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
  have not been included_
- [ ] I need help with writing tests
- [x] Not needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l3q2wnlw48fuf1l3a/giphy.gif)
