### PR TITLE
made clonestamp brush clone blocks only above the target block (but including the target itself)

### DIFF
--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
@@ -7,7 +7,6 @@ import com.github.kevindagame.util.RotationAxis;
 import com.github.kevindagame.util.Shapes;
 import com.github.kevindagame.util.Utils;
 import com.github.kevindagame.util.VoxelMessage;
-import com.github.kevindagame.voxelsniper.location.BaseLocation;
 import com.github.kevindagame.voxelsniper.location.VoxelLocation;
 import org.jetbrains.annotations.NotNull;
 

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
@@ -30,9 +30,8 @@ public class CloneStampBrush extends StampBrush {
      * @param v the caller
      */
     private void clone(final SnipeData v) {
-        VoxelLocation point = getTargetBlock().getLocation().makeMutable();
-        point.add(0, v.getcCen(), 0);
-        BaseLocation startingPoint = point.makeImmutable();
+        VoxelLocation startingPoint = getTargetBlock().getLocation().makeMutable();
+        startingPoint.add(0, v.getcCen(), 0);
         var positions = Shapes.cylinder(startingPoint, RotationAxis.Y, v.getBrushSize(), v.getVoxelHeight(), (v.getVoxelHeight() / 2.0) - 1, false);
         this.clone.clear();
         this.toStamp.clear();

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/brush/CloneStampBrush.java
@@ -11,7 +11,6 @@ import com.github.kevindagame.voxelsniper.location.BaseLocation;
 import com.github.kevindagame.voxelsniper.location.VoxelLocation;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,9 +20,6 @@ import java.util.List;
  * @author Voxel
  */
 public class CloneStampBrush extends StampBrush {
-
-    private BaseLocation startingPoint;
-
 
     /**
      * The clone method is used to grab a snapshot of the selected area dictated blockPositionY targetBlock.x y z v.brushSize v.voxelHeight and v.cCen.
@@ -36,8 +32,8 @@ public class CloneStampBrush extends StampBrush {
     private void clone(final SnipeData v) {
         VoxelLocation point = getTargetBlock().getLocation().makeMutable();
         point.add(0, v.getcCen(), 0);
-        this.startingPoint = point.makeImmutable();
-        var positions = Shapes.cylinder(startingPoint, RotationAxis.Y, v.getBrushSize(), v.getVoxelHeight(), 0, false);
+        BaseLocation startingPoint = point.makeImmutable();
+        var positions = Shapes.cylinder(startingPoint, RotationAxis.Y, v.getBrushSize(), v.getVoxelHeight(), (v.getVoxelHeight() / 2.0) - 1, false);
         this.clone.clear();
         this.toStamp.clear();
         this.sorted = false;

--- a/VoxelSniperCore/src/main/java/com/github/kevindagame/util/Shapes.java
+++ b/VoxelSniperCore/src/main/java/com/github/kevindagame/util/Shapes.java
@@ -1,6 +1,5 @@
 package com.github.kevindagame.util;
 
-import com.github.kevindagame.snipe.Undo;
 import com.github.kevindagame.voxelsniper.block.BlockFace;
 import com.github.kevindagame.voxelsniper.block.IBlock;
 import com.github.kevindagame.voxelsniper.location.BaseLocation;
@@ -81,7 +80,7 @@ public class Shapes {
         return positions;
     }
 
-    public static List<BaseLocation> cylinder(BaseLocation centerPoint, RotationAxis axis, int brushSize, int height, int shift, boolean smooth) {
+    public static List<BaseLocation> cylinder(BaseLocation centerPoint, RotationAxis axis, int brushSize, int height, double shift, boolean smooth) {
         List<BaseLocation> positions = new ArrayList<>();
         for (int y = 0; y < height; y++) {
             var pos = axis.getLocationTranslator().invoke(centerPoint.getWorld(), 0, (int) (y - (height / 2.0) + 1 + shift), 0);
@@ -120,8 +119,6 @@ public class Shapes {
         final List<BaseLocation> positions = new ArrayList<>();
         final int absoluteHeight = Math.abs(height);
         final boolean negative = height < 0;
-
-        final Undo undo = new Undo();
 
         final int brushSizeTimesVoxelHeight = brushSize * absoluteHeight;
         final double stepScale = ((brushSize * brushSize) + brushSizeTimesVoxelHeight + brushSizeTimesVoxelHeight) / 5.0;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Changes clonestamp brush to be more useful in practise, making the tagret block the 'start' point instead of the center-block.
https://discord.com/channels/733237907040632924/981234987451944970/1284865473728745493

## QA Instructions, Screenshots, Recordings

tested on spigot 1.20.1

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
  have not been included_
- [ ] I need help with writing tests
- [ ] Not needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/u0Je4lbiNpC9GrYiQ9/giphy.gif)
